### PR TITLE
andreas - python implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,13 @@ endif
 #
 # User friendly rules
 #
-all: square-all sparsemax-all
-test: square-test sparsemax-test
-lint: square-lint sparsemax-lint
+all: reference-all square-all sparsemax-all
+test: reference-test square-test sparsemax-test
+lint: reference-lint square-lint sparsemax-lint
 
 include tensorflow-sparsemax/build.mk
 include tensorflow-square/build.mk
+include python-reference/build.mk
 
 clean:
 	rm -f **/**/*.o

--- a/python-reference/build.mk
+++ b/python-reference/build.mk
@@ -1,0 +1,9 @@
+
+# user friendly targets
+reference-all: test lint
+
+reference-test:
+	nosetests -v -s python-reference/test/test_*.py
+
+reference-lint:
+	pep8 --show-source --show-pep8 ./

--- a/python-reference/build.mk
+++ b/python-reference/build.mk
@@ -6,4 +6,4 @@ reference-test:
 	nosetests -v -s python-reference/test/test_*.py
 
 reference-lint:
-	pep8 --show-source --show-pep8 ./
+	pep8 --show-source --show-pep8 python-reference/

--- a/python-reference/sparsemax.py
+++ b/python-reference/sparsemax.py
@@ -1,0 +1,73 @@
+import numpy as np
+
+
+def forward(z):
+    """forward pass for sparsemax
+
+    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
+    the the z-vector.
+    """
+
+    # sort z
+    z_sorted = np.sort(z, axis=1)[:, ::-1]
+
+    # calculate k(z)
+    z_cumsum = np.cumsum(z_sorted, axis=1)
+    k = np.arange(1, z.shape[1] + 1)
+    z_check = 1 + k * z_sorted > z_cumsum
+    # use argmax to get the index by row as .nonzero() doesn't
+    # take an axis argument. np.argmax return the first index, but the last
+    # index is required here, use np.flip to get the last index and
+    # `z.shape[axis]` to compensate for np.flip afterwards.
+    k_z = z.shape[1] - np.argmax(z_check[:, ::-1], axis=1)
+
+    # calculate tau(z)
+    tau_sum = z_cumsum[np.arange(0, z.shape[0]), k_z - 1]
+    tau_z = ((tau_sum - 1) / k_z).reshape(-1, 1)
+
+    # calculate p
+    return np.maximum(0, z - tau_z)
+
+
+def jacobian(z):
+    """jacobian for sparsemax
+
+    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
+    the the z-vector.
+    """
+
+    # Construct S(z)
+    # Possibly this could be reduced to just calculating k(z)
+    p = forward(z)
+    s = p > 0
+    s_float = s.astype('float64')
+
+    # row-wise outer product
+    # http://stackoverflow.com/questions/31573856/theano-row-wise-outer-product-between-two-matrices
+    jacobian = s_float[:, :, np.newaxis] * s_float[:, np.newaxis, :]
+    jacobian /= - np.sum(s, axis=1)[:, np.newaxis, np.newaxis]
+
+    # add delta_ij
+    obs, index = s.nonzero()
+    jacobian[obs, index, index] += 1
+
+    return jacobian
+
+
+def Rop(z, v):
+    """Jacobian vector product (Rop) for sparsemax
+
+    This calculates [J(z_i) * v_i, ...]. `z` is a 2d-array, where axis 1
+    (each row) is assumed to be the the z-vector. `v` is a matrix where
+    axis 1 (each row) is assumed to be the `v-vector`.
+    """
+
+    # Construct S(z)
+    p = forward(z)
+    s = p > 0
+
+    # Calculate \hat{v}, which will be a vector (scalar for each z)
+    v_hat = np.sum(v * s, axis=1) / np.sum(s, axis=1)
+
+    # Calculates J(z) * v
+    return s * (v - v_hat[:, np.newaxis])

--- a/python-reference/sparsemax.py
+++ b/python-reference/sparsemax.py
@@ -1,8 +1,11 @@
 import numpy as np
 
 
-def tau(z):
-    """Calculates tau(z)
+def forward(z):
+    """forward pass for sparsemax
+
+    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
+    the the z-vector.
     """
 
     # sort z
@@ -20,16 +23,9 @@ def tau(z):
 
     # calculate tau(z)
     tau_sum = z_cumsum[np.arange(0, z.shape[0]), k_z - 1]
-    return ((tau_sum - 1) / k_z).reshape(-1, 1)
+    tau_z = ((tau_sum - 1) / k_z).reshape(-1, 1)
 
-
-def forward(z):
-    """forward pass for sparsemax
-
-    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
-    the the z-vector.
-    """
-    return np.maximum(0, z - tau(z))
+    return np.maximum(0, z - tau_z)
 
 
 def jacobian(z):

--- a/python-reference/sparsemax.py
+++ b/python-reference/sparsemax.py
@@ -1,11 +1,8 @@
 import numpy as np
 
 
-def forward(z):
-    """forward pass for sparsemax
-
-    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
-    the the z-vector.
+def tau(z):
+    """Calculates tau(z)
     """
 
     # sort z
@@ -23,10 +20,16 @@ def forward(z):
 
     # calculate tau(z)
     tau_sum = z_cumsum[np.arange(0, z.shape[0]), k_z - 1]
-    tau_z = ((tau_sum - 1) / k_z).reshape(-1, 1)
+    return ((tau_sum - 1) / k_z).reshape(-1, 1)
 
-    # calculate p
-    return np.maximum(0, z - tau_z)
+
+def forward(z):
+    """forward pass for sparsemax
+
+    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
+    the the z-vector.
+    """
+    return np.maximum(0, z - tau(z))
 
 
 def jacobian(z):

--- a/python-reference/sparsemax.py
+++ b/python-reference/sparsemax.py
@@ -25,6 +25,7 @@ def forward(z):
     tau_sum = z_cumsum[np.arange(0, z.shape[0]), k_z - 1]
     tau_z = ((tau_sum - 1) / k_z).reshape(-1, 1)
 
+    # calculate p
     return np.maximum(0, z - tau_z)
 
 

--- a/python-reference/sparsemax_loss.py
+++ b/python-reference/sparsemax_loss.py
@@ -1,0 +1,29 @@
+
+import numpy as np
+
+import sparsemax
+
+
+def forward(z, q):
+    """Calculates the sparsemax loss function
+
+    this will process a 2d-array $z$, where axis 1 (each row) is assumed to be
+    the the z-vector. q is a binary matrix of same shape, containing the labels
+    """
+
+    # Calculate q^T * z
+    z_k = np.sum(q * z, axis=1)
+
+    # calculate sum over S(z)
+    tau_z = sparsemax.tau(z)
+    s = z > tau_z
+    S_sum = np.sum(s * (z**2 - tau_z**2), axis=1)
+
+    # because q is binary, sum([q_1^2, q_2^2, ...]) is just sum(q)
+    q_norm = np.sum(q, axis=1)
+
+    return -z_k + 0.5 * S_sum + 0.5 * q_norm
+
+
+def grad(z, q):
+    return -q + sparsemax.forward(z)

--- a/python-reference/sparsemax_loss.py
+++ b/python-reference/sparsemax_loss.py
@@ -15,9 +15,10 @@ def forward(z, q):
     z_k = np.sum(q * z, axis=1)
 
     # calculate sum over S(z)
-    tau_z = sparsemax.tau(z)
-    s = z > tau_z
-    S_sum = np.sum(s * (z**2 - tau_z**2), axis=1)
+    p = sparsemax.forward(z)
+    s = p > 0
+    # z_i^2 - tau(z)^2 = p_i (2 * z_i - p_i) for i \in S(z)
+    S_sum = np.sum(s * p * (2 * z - p), axis=1)
 
     # because q is binary, sum([q_1^2, q_2^2, ...]) is just sum(q)
     q_norm = np.sum(q, axis=1)

--- a/python-reference/sparsemax_regression.py
+++ b/python-reference/sparsemax_regression.py
@@ -1,0 +1,54 @@
+
+import math
+
+import numpy as np
+import scipy
+
+import sparsemax
+import sparsemax_loss
+
+
+class SparsemaxRegression:
+    def __init__(self, input_size, output_size,
+                 regualizer=1e-1, learning_rate=1e-2):
+        # intialize weights
+        self.input_size = input_size
+        self.output_size = output_size
+        self.reset()
+
+        # set hyper parameters
+        self.regualizer = regualizer
+        self.learning_rate = learning_rate
+
+    def reset(self, random_state=None):
+        self.W = scipy.stats.truncnorm.rvs(
+            -2, 2, size=(self.input_size, self.output_size),
+            random_state=random_state
+        )
+        self.W *= math.sqrt(2 / (self.input_size + self.output_size))
+        self.b = np.zeros((1, self.output_size))
+
+    def gradient(self, x, t):
+        n = x.shape[0]
+        z = np.dot(x, self.W) + self.b
+        loss_grad = sparsemax_loss.grad(z, t)
+
+        return (
+            np.dot(x.T, loss_grad) / n,
+            np.sum(loss_grad, axis=0) / n
+        )
+
+    def update(self, x, t):
+        (dW, db) = self.gradient(x, t)
+
+        self.W += - self.learning_rate * (self.regualizer * self.W + dW)
+        self.b += - self.learning_rate * (self.regualizer * self.b + db)
+
+    def loss(self, x, t):
+        l2 = np.linalg.norm(self.W, 'fro')**2 + np.linalg.norm(self.b, 2)**2
+
+        return 0.5 * self.regualizer * l2 + \
+            np.mean(sparsemax_loss.forward(np.dot(x, self.W) + self.b, t))
+
+    def predict(self, x):
+        return sparsemax.forward(np.dot(x, self.W) + self.b)

--- a/python-reference/test/_test.py
+++ b/python-reference/test/_test.py
@@ -1,0 +1,5 @@
+import os.path as path
+import sys
+
+thisdir = path.dirname(path.realpath(__file__))
+sys.path.append(path.join(thisdir, '..'))

--- a/python-reference/test/test_sparsemax.py
+++ b/python-reference/test/test_sparsemax.py
@@ -130,3 +130,14 @@ def test_Rop():
         np.einsum('oij,oi->oj', jacobian_exact, v),  # J(z) * v for each obs.
         sparsemax.Rop(z, v)
     )
+
+
+def test_sparsemax_on_examples():
+    """ check sparsemax on a harcoded examples"""
+    twod_input_vector = np.array([[5, 3, 0], [2, 2.7, 0]])
+    value_expected = np.array([[1, 0, 0],
+                              [((2 + 1) - 2.7) / 2,
+                               ((2.7 + 1) - 2) / 2, 0]])
+
+    output_value = sparsemax.forward(twod_input_vector)
+    np.testing.assert_almost_equal(output_value, value_expected)

--- a/python-reference/test/test_sparsemax.py
+++ b/python-reference/test/test_sparsemax.py
@@ -1,0 +1,132 @@
+import _test
+from nose.tools import *
+
+import warnings
+import numpy as np
+import numdifftools
+
+import sparsemax
+
+
+def test_sparsemax_of_zero():
+    """check sparsemax proposition 1, part 1"""
+    z = np.zeros((1, 10))
+
+    np.testing.assert_array_equal(
+        sparsemax.forward(z),
+        np.ones_like(z) / z.size
+    )
+
+
+def test_sparsemax_of_inf():
+    """check sparsemax proposition 1, part 2"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+
+    # assume |A(z)| = 1, as z is continues random
+    z_sort_arg = np.argsort(z, axis=1)[:, ::-1]
+    z_sort = np.sort(z, axis=-1)[:, ::-1]
+    gamma_z = z_sort[:, 0] - z_sort[:, 1]
+    epsilon = (0.99 * gamma_z * 1).reshape(-1, 1)
+
+    # construct the expected 1_A(z) array
+    p_expected = np.zeros((100, 10))
+    p_expected[np.arange(0, 100), z_sort_arg[:, 0]] = 1
+
+    np.testing.assert_array_equal(
+        sparsemax.forward((1/epsilon) * z),
+        p_expected
+    )
+
+
+def test_constant_add():
+    """check sparsemax proposition 2"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    c = np.random.uniform(low=-3, high=3, size=(100, 1))
+
+    np.testing.assert_almost_equal(
+        sparsemax.forward(z + c),
+        sparsemax.forward(z)
+    )
+
+
+def test_permutation():
+    """check sparsemax proposition 3"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    p = sparsemax.forward(z)
+
+    for i in range(100):
+        per = np.random.permutation(10)
+
+        np.testing.assert_array_equal(
+            sparsemax.forward(z[i, per].reshape(1, -1)),
+            p[i, per].reshape(1, -1)
+        )
+
+
+def test_diffrence():
+    """check sparsemax proposition 4"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    p = sparsemax.forward(z)
+
+    for val in range(0, 100):
+        for i in range(0, 10):
+            for j in range(0, 10):
+                # check condition, the obesite pair will be checked anyway
+                if z[val, i] > z[val, j]:
+                    continue
+
+                assert_true(
+                    0 <= p[val, j] - p[val, i] <= z[val, j] - z[val, i],
+                    "0 <= %.10f <= %.10f" % (
+                        p[val, j] - p[val, i], z[val, j] - z[val, i]
+                    )
+                )
+
+
+def test_two_dimentional():
+    """check two dimentation sparsemax case"""
+    t = np.linspace(-2, 2, 100)
+    z = np.vstack([
+        t, np.zeros(100)
+    ]).T
+
+    p = sparsemax.forward(z)
+    p0_expected = np.select([t < -1, t <= 1, t > 1], [0, (t + 1) / 2, 1])
+
+    np.testing.assert_almost_equal(p[:, 0], p0_expected)
+    np.testing.assert_almost_equal(p[:, 1], 1 - p0_expected)
+
+
+def test_two_dimentional_jacobian():
+    """check two dimentation sparsemax jacobian against approiximation"""
+    t = np.linspace(-2, 2, 100)
+    z = np.vstack([
+        t, np.zeros(100)
+    ]).T
+
+    Jacobian_approx = numdifftools.Jacobian(
+        lambda z_i: sparsemax.forward(z_i[np.newaxis, :])[0]
+    )
+
+    jacobian_exact = sparsemax.jacobian(z)
+
+    for i, z_i in enumerate(z):
+        with warnings.catch_warnings(record=True) as w:
+            # numdifftools causes a warning, a better filter could be made
+            np.testing.assert_almost_equal(
+                jacobian_exact[i, :, :],
+                Jacobian_approx(z_i)
+            )
+
+
+def test_Rop():
+    """check sparsemax jacobian times vector (Rop), aginst exact jacobian"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    v = np.random.uniform(low=-3, high=3, size=(100, 10))
+
+    jacobian_exact = sparsemax.jacobian(z)
+
+    np.testing.assert_almost_equal(
+        np.einsum('oij,oi->oj', jacobian_exact, v),  # J(z) * v for each obs.
+        sparsemax.Rop(z, v)
+    )

--- a/python-reference/test/test_sparsemax_loss.py
+++ b/python-reference/test/test_sparsemax_loss.py
@@ -80,3 +80,13 @@ def test_gradient():
                 gradient_exact[i, :],
                 gradient_approx(z_i)
             )
+
+
+def test_loss_on_example():
+    """ check sparsemax-loss on a hardcoded example"""
+    twod_input = np.array([[5, 3, 7, 0], [3.6, 2.7, 3.5, 0]])
+    labels = np.array([[0, 0, 1, 0], [0, 0, 1, 0]])
+    expected_loss = np.array([0, 0.3025])
+
+    output = sparsemax_loss.forward(twod_input, labels)
+    np.testing.assert_almost_equal(expected_loss, output)

--- a/python-reference/test/test_sparsemax_loss.py
+++ b/python-reference/test/test_sparsemax_loss.py
@@ -1,0 +1,82 @@
+import _test
+from nose.tools import *
+
+import warnings
+import operator
+import numpy as np
+import numdifftools
+
+import sparsemax
+import sparsemax_loss
+
+
+def test_constant_add():
+    """check sparsemax-loss proposition 3"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    c = np.random.uniform(low=-3, high=3, size=(100, 1))
+    q = np.zeros((100, 10))
+    q[np.arange(0, 100), np.random.randint(0, 10, size=100)] = 1
+
+    np.testing.assert_almost_equal(
+        sparsemax_loss.forward(z, q),
+        sparsemax_loss.forward(z + c, q)
+    )
+
+
+def test_positive():
+    """check sparsemax-loss proposition 4"""
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    q = np.zeros((100, 10))
+    q[np.arange(0, 100), np.random.randint(0, 10, size=100)] = 1
+
+    loss = sparsemax_loss.forward(z, q)
+    np.testing.utils.assert_array_compare(
+        operator.__ge__, loss, np.zeros_like(loss)
+    )
+
+
+def test_zero_loss():
+    """check sparsemax-loss proposition 5"""
+    # construct z and q, such that z_k >= 1 + max_{j!=k} z_k holds for
+    # delta_0 = 1.
+    z = np.random.uniform(low=-3, high=3, size=(100, 10))
+    z[:, 0] = np.max(z, axis=1) + 1.05
+
+    q = np.zeros((100, 10))
+    q[:, 0] = 1
+
+    np.testing.assert_almost_equal(
+        sparsemax_loss.forward(z, q),
+        0
+    )
+
+    np.testing.assert_almost_equal(
+        sparsemax.forward(z),
+        q
+    )
+
+
+def test_gradient():
+    """check sparsemax-loss gradient, against approximation"""
+    t = np.linspace(-2, 2, 100)
+    z = np.vstack([
+        t, np.zeros(100)
+    ]).T
+    q = np.zeros((100, 2))
+    q[np.arange(0, 100), np.random.randint(0, 2, size=100)] = 1
+
+    gradient_exact = sparsemax_loss.grad(z, q)
+
+    for i, (z_i, q_i) in enumerate(zip(z, q)):
+        gradient_approx = numdifftools.Gradient(
+            lambda z_i: sparsemax_loss.forward(
+                z_i[np.newaxis, :], q_i[np.newaxis, :]
+            )[0]
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            # numdifftools causes a warning, a better filter could be made
+            np.testing.assert_almost_equal(
+                gradient_exact[i, :],
+                gradient_approx(z_i)
+            )

--- a/python-reference/test/test_sparsemax_regression.py
+++ b/python-reference/test/test_sparsemax_regression.py
@@ -1,0 +1,107 @@
+import _test
+from nose.tools import *
+
+import collections
+
+import numpy as np
+from sklearn import datasets
+from sklearn.preprocessing import LabelBinarizer
+from sklearn.model_selection import StratifiedKFold
+
+from sparsemax_regression import SparsemaxRegression
+
+ModelResults = collections.namedtuple('ModelResults', ['loss', 'missrate'])
+
+
+class ModelTest:
+    def __init__(self, model, dataset, epochs=1000,
+                 random_state=None, verbose=False):
+        self.model = model
+        self.dataset = dataset
+
+        self.epochs = epochs
+        self.random_state = random_state
+        self.verbose = verbose
+
+        # setup data
+        self.x = dataset.data
+        self.t = LabelBinarizer().fit_transform(dataset.target)
+
+    def test_fold(self, fold, train_index, test_index):
+        # select datasets
+        x_train = self.x[train_index, :]
+        t_train = self.t[train_index, :]
+        x_test = self.x[test_index, :]
+        t_test = self.t[test_index, :]
+
+        # reset model
+        self.model.reset(random_state=self.random_state)
+
+        # train model
+        for epoch in range(0, self.epochs):
+            self.model.update(x_train, t_train)
+
+        # prediction on test data
+        loss = self.model.loss(x_test, t_test)
+        target = np.argmax(t_test, axis=1)
+        predict = np.argmax(self.model.predict(x_test), axis=1)
+        missrate = np.mean(predict != target)
+
+        # verbose output
+        if (self.verbose):
+            print('cross validation fold: %d' % fold)
+            print('      loss: %f' % loss)
+            print('  missrate: %f' % missrate)
+            print('   predict: %s' % np.array_str(predict))
+            print('    target: %s' % np.array_str(target))
+
+        return ModelResults(loss, missrate)
+
+    def test(self, loss, missrate):
+        # cross validation
+        skf = StratifiedKFold(
+            n_splits=5, shuffle=True, random_state=self.random_state
+        )
+
+        for fold, (train_index, test_index) in \
+                enumerate(skf.split(self.dataset.data, self.dataset.target)):
+            # fit model and get final test performance
+            results = self.test_fold(fold, train_index, test_index)
+
+            # assert prediction scores
+            assert_true(results.loss < loss)
+            assert_true(results.missrate < missrate)
+
+
+def test_iris_classifier():
+    """check sparsemax regression on the iris dataset"""
+
+    # get data
+    iris = datasets.load_iris()
+
+    # intialize model
+    model = SparsemaxRegression(
+        input_size=4, output_size=3,
+        regualizer=1e-1, learning_rate=1e-2
+    )
+
+    # setup model tester
+    tester = ModelTest(model, iris, random_state=42, verbose=False)
+    tester.test(loss=0.2, missrate=0.1)
+
+
+def test_mnist_classifier():
+    """check sparsemax regression on the digits dataset"""
+
+    # get data
+    mnist = datasets.load_digits()
+
+    # intialize model
+    model = SparsemaxRegression(
+        input_size=mnist.data.shape[1], output_size=10,
+        regualizer=1e-1, learning_rate=1e-2
+    )
+
+    # setup model tester
+    tester = ModelTest(model, mnist, random_state=42, verbose=False)
+    tester.test(loss=0.2, missrate=0.1)


### PR DESCRIPTION
- [x] sparsemax added
- [x] sparsemax-loss function
- [x] sparsemax "logistic" regression

I'm getting about 3% - 6% misclassification on the iris and digits (reduced mnist) dataset. I think that is fine, since it's just a "logistic" regression and thus can't fit non-linearities.

Run `make` to test and pep8 lint.
