### PR TITLE
Sparsemax GPU v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ endif
 # User friendly rules
 #
 all: reference-all square-all sparsemax-all sparsemax-python-all softmax-all benchmark-all
+build: square-build sparsemax-build
 test: reference-test square-test sparsemax-test sparsemax-python-test softmax-test
 lint: reference-lint square-lint sparsemax-lint sparsemax-python-lint softmax-lint benchmark-lint
 

--- a/tensorflow_sparsemax/build.mk
+++ b/tensorflow_sparsemax/build.mk
@@ -13,7 +13,9 @@ tensorflow_sparsemax/kernel/sparsemax_loss.cu.o: tensorflow_sparsemax/kernel/spa
 # user friendly targets
 sparsemax-all: sparsemax-test sparsemax-lint
 
-sparsemax-test: tensorflow_sparsemax/kernel/sparsemax.so tensorflow_sparsemax/kernel/sparsemax_loss.so
+sparsemax-build: tensorflow_sparsemax/kernel/sparsemax.so tensorflow_sparsemax/kernel/sparsemax_loss.so
+
+sparsemax-test: sparsemax-build
 	nosetests --nologcapture -v -s tensorflow_sparsemax/test/test_*.py
 
 sparsemax-lint:

--- a/tensorflow_sparsemax/kernel/sparsemax.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax.cc
@@ -57,10 +57,14 @@ class SparsemaxOp : public OpKernel {
     OP_REQUIRES_OK(context, context->allocate_output(0, logits_in.shape(),
                                                      &probability_out));
 
-    // Create temporary tensor used for storing bitonic sort
+    // Create temporary tensor used for storing sorted values. The tensor is
+    // only used in the GPU op.
     Tensor temp_sorted;
-    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
-                                                   logits_in.shape(), &temp_sorted));
+    if (std::is_same<Device, GPUDevice>::value) {
+      OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
+                                                     logits_in.shape(),
+                                                     &temp_sorted));
+    }
 
     // Setup data view
     auto input = logits_in.matrix<T>();

--- a/tensorflow_sparsemax/kernel/sparsemax.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax.cc
@@ -64,6 +64,10 @@ class SparsemaxOp : public OpKernel {
       OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
                                                      logits_in.shape(),
                                                      &temp_sorted));
+    } else {
+      OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
+                                                     TensorShape({0, 0}),
+                                                     &temp_sorted));
     }
 
     // Setup data view

--- a/tensorflow_sparsemax/kernel/sparsemax.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax.cc
@@ -67,7 +67,8 @@ class SparsemaxOp : public OpKernel {
     auto sorted = temp_sorted.matrix<T>();
     auto output = probability_out->matrix<T>();
 
-    functor::Sparsemax<Device, T>()(input, sorted, output);
+    const Device& eigen_device = context->eigen_device<Device>();
+    functor::Sparsemax<Device, T>()(eigen_device, input, sorted, output);
   }
 };
 

--- a/tensorflow_sparsemax/kernel/sparsemax.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax.cc
@@ -57,11 +57,17 @@ class SparsemaxOp : public OpKernel {
     OP_REQUIRES_OK(context, context->allocate_output(0, logits_in.shape(),
                                                      &probability_out));
 
+    // Create temporary tensor used for storing bitonic sort
+    Tensor temp_sorted;
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
+                                                   logits_in.shape(), &temp_sorted));
+
     // Setup data view
     auto input = logits_in.matrix<T>();
+    auto sorted = temp_sorted.matrix<T>();
     auto output = probability_out->matrix<T>();
 
-    functor::Sparsemax<Device, T>()(input, output);
+    functor::Sparsemax<Device, T>()(input, sorted, output);
   }
 };
 

--- a/tensorflow_sparsemax/kernel/sparsemax_functor.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax_functor.cc
@@ -15,10 +15,14 @@ typedef Eigen::GpuDevice GPUDevice;
 
 namespace functor {
 
+#define UNUSED(x) (void)(x)
+
 template <typename T>
 struct Sparsemax<CPUDevice, T> {
   void operator()(typename TTypes<T>::ConstMatrix input,
+                  typename TTypes<T>::Matrix sorted_unused, //only used for GPU
                   typename TTypes<T>::Matrix output) {
+    UNUSED(sorted_unused); // remove unused warning
 
     // define integers {0, 1} in matching template type
     T zero = static_cast<T>(0);

--- a/tensorflow_sparsemax/kernel/sparsemax_functor.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax_functor.cc
@@ -19,9 +19,11 @@ namespace functor {
 
 template <typename T>
 struct Sparsemax<CPUDevice, T> {
-  void operator()(typename TTypes<T>::ConstMatrix input,
+  void operator()(const CPUDevice& d,
+                  typename TTypes<T>::ConstMatrix input,
                   typename TTypes<T>::Matrix sorted_unused, //only used for GPU
                   typename TTypes<T>::Matrix output) {
+    UNUSED(d); // remove unused warning
     UNUSED(sorted_unused); // remove unused warning
 
     // define integers {0, 1} in matching template type

--- a/tensorflow_sparsemax/kernel/sparsemax_functor.cu.cc
+++ b/tensorflow_sparsemax/kernel/sparsemax_functor.cu.cc
@@ -229,7 +229,7 @@ struct Sparsemax<GPUDevice, T> {
     // Put results in output as the the sorted and cumsum needs to be used
     // together.
     Eigen::internal::SumReducer<T> reducer;
-    output.device(d) = temp.scan(1, reducer, false).eval();
+    output.device(d) = temp.scan(1, reducer, false);
 
     // Calculate threshold used in support calculation.
     // Replace sorted matrix, with the threshold booleans.
@@ -238,7 +238,7 @@ struct Sparsemax<GPUDevice, T> {
     // Sum each row, to get the support index.
     // This will reuse the temporary matrix, which is larger than required,
     // but the results will just be stored as if it was a flat vector.
-    temp.device(d) = temp.sum(along_class).eval();
+    temp.device(d) = temp.sum(along_class);
 
     // Calculate tau
     // Overwrites temp results with tau(z), again this just uses temp

--- a/tensorflow_sparsemax/kernel/sparsemax_functor.h
+++ b/tensorflow_sparsemax/kernel/sparsemax_functor.h
@@ -8,7 +8,8 @@ namespace functor {
 
 template <typename Device, typename T>
 struct Sparsemax {
-  void operator()(typename TTypes<T>::ConstMatrix input,
+  void operator()(const Device& d,
+                  typename TTypes<T>::ConstMatrix input,
                   typename TTypes<T>::Matrix sorted,
                   typename TTypes<T>::Matrix output);
 };

--- a/tensorflow_sparsemax/kernel/sparsemax_functor.h
+++ b/tensorflow_sparsemax/kernel/sparsemax_functor.h
@@ -9,6 +9,7 @@ namespace functor {
 template <typename Device, typename T>
 struct Sparsemax {
   void operator()(typename TTypes<T>::ConstMatrix input,
+                  typename TTypes<T>::Matrix sorted,
                   typename TTypes<T>::Matrix output);
 };
 

--- a/tensorflow_square/build.mk
+++ b/tensorflow_square/build.mk
@@ -5,7 +5,10 @@ tensorflow_square/kernel/custom_square.so: tensorflow_square/kernel/custom_squar
 # user friendly targets
 square-all: square-test square-lint
 
-square-test: tensorflow_square/kernel/custom_square.so
+
+square-build: tensorflow_square/kernel/custom_square.so
+
+square-test: square-build
 	nosetests --nologcapture -v -s tensorflow_square/test/test_*.py
 
 square-lint:


### PR DESCRIPTION
This implements a sparsemax GPU that also parallelizes along the vectors (not just the observations). It uses a naïve odd-even sort (`O(N^2)` -> `O(N)`parallelized). This is just until @FrederikWR shows us his GPU sorting skillings 🚀 .

- [x] implement too naïve odd-even sort kernel
- [ ] implement amazing sort kernel
- [x] use eigen c++ cumsum
- [x] implement support boolean kernel
- [x] use eigen c++ sum (is an `argmax` when values are binary).
- [x] implement tau kernel
- [x] implement probability input mapping kernel
- [x] don't allocate extra memory on CPU

~~Note that the odd-even sort kernel does not work for vectors that are larger than the block size. This is because `__syncthreads` only synchronizes treads within the block.~~ This has been fixed (naively).